### PR TITLE
:sparkles: class sdldisplay

### DIFF
--- a/.github/workflows/pain_au_chocolat.yml
+++ b/.github/workflows/pain_au_chocolat.yml
@@ -55,6 +55,9 @@ jobs:
       - name: "Make"
         timeout-minutes: 2
         run: make
+      - name: "Make Graphicals"
+        timeout-minutes: 2
+        run: make graphicals
       - name: "Check existing executables"
         run: |
           LIST=$(echo $EXECUTABLES | tr ',' ' ')

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ unit_tests
 obj/
 build
 arcade
+*.so

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,16 @@ EXTENSION = cpp
 
 # ============= FLAGS ============= #
 
-FLAGS = -I./include -I./src \
-	$(shell find include src -type d -exec echo -I{} \;) \
-	-MMD -MP $(FLAGS_LIB) \
+FLAGS = -I./include \
+		-I./src \
+		-I./src/core \
+		-I./src/interfaces \
+		-MMD -MP $(FLAGS_LIB) \
+
+FLAGS_SDL = `sdl2-config --cflags --libs` $(FLAGS_LIB) \
+			-I./src/interfaces \
+			-I./include \
+			-I./src/core \
 
 FLAGS_TEST = $(FLAGS) -lcriterion --coverage \
 
@@ -47,13 +54,17 @@ NAME_LIB	= \
 
 NAME	=	arcade
 
+NAME_SDL = lib/arcade_sdl2.so
+
 # ============= SOURCES ============= #
 
 SRC_LIB	=	\
 
 SRC_MAIN	=	main.cpp \
 
-SRC	= 	$(shell find src -type f -name "*.cpp" ! -name "main.cpp") \
+SRC	= 	src/core/Core.cpp \
+
+SRC_SDL = src/interfaces/SDL/SDLDisplay.cpp \
 
 SRC_TESTS	= 	tests/test_1.cpp \
 
@@ -66,6 +77,9 @@ $(NAME): $(OBJ_SRC) $(OBJ_MAIN)
 
 $(NAME_LIB): $(OBJ)
 	ar rc $(NAME_LIB) $(OBJ)
+
+graphicals:
+	$(COMPILER) -o $(NAME_SDL) -shared -fPIC $(SRC_SDL) $(FLAGS_SDL)
 
 # ============= CLEANS ============= #
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ FLAGS = -I./include \
 		-I./src/interfaces \
 		-MMD -MP $(FLAGS_LIB) \
 
-FLAGS_SDL = `sdl2-config --cflags --libs` $(FLAGS_LIB) \
+FLAGS_SDL = $(FLAGS_LIB) -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer \
 			-I./src/interfaces \
 			-I./include \
 			-I./src/core \
@@ -47,6 +47,9 @@ FLAGS_SDL = `sdl2-config --cflags --libs` $(FLAGS_LIB) \
 FLAGS_TEST = $(FLAGS) -lcriterion --coverage \
 
 FLAGS_LIB = -std=c++20 -Wall -Wextra -Werror
+
+CXXFLAGS += -I/usr/include/SDL2 -I./src/interfaces -I./include -I./src/core
+LDFLAGS += -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer
 
 # ============= NAMES ============= #
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ FLAGS = -I./include \
 		-I./src/interfaces \
 		-MMD -MP $(FLAGS_LIB) \
 
-FLAGS_SDL = $(FLAGS_LIB) -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer \
+FLAGS_SDL = $(FLAGS_LIB) -lSDL2 -lSDL2_image \
 			-I./src/interfaces \
 			-I./include \
 			-I./src/core \
@@ -68,6 +68,7 @@ SRC_MAIN	=	main.cpp \
 SRC	= 	src/core/Core.cpp \
 
 SRC_SDL = src/interfaces/SDL/SDLDisplay.cpp \
+		 src/interfaces/SDL/SDL2.cpp \
 
 SRC_TESTS	= 	tests/test_1.cpp \
 

--- a/include/Keys.hpp
+++ b/include/Keys.hpp
@@ -63,6 +63,7 @@ namespace Key {
         MOUSE_BUTTON_4,
         MOUSE_BUTTON_5,
         MOUSE_SCROLL,
+        MOUSE_MOVE,
 
         SPACE,
         ENTER,

--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -73,8 +73,8 @@ Core::StateCore Core::Core::events()
 void Core::Core::draw()
 {
     _display->clear();
-    for (auto drawable : _game->getDrawables())
-        _display->draw(drawable);
+    for (const std::unique_ptr<IDrawable>& drawable : _game->getDrawables())
+        _display->draw(*drawable.get());
     for (auto sound : _game->getSound())
         _display->handleSound(sound);
     _display->display();

--- a/src/core/Event.hpp
+++ b/src/core/Event.hpp
@@ -11,6 +11,26 @@
 
 class Event {
 public:
+    enum KeyStatus {
+        KEY_PRESSED,
+        KEY_RELEASED
+    };
+
+    struct MousePos {
+        int x;
+        int y;
+    };
+
+    struct MouseStatusClick {
+        MousePos pos;
+        KeyStatus status;
+    };
+
+    struct MouseStatusScroll {
+        MousePos pos;
+        float value;
+    };
+
     Event(
         enum Key::KeyCode key,
         std::any value

--- a/src/interfaces/IDisplayModule.hpp
+++ b/src/interfaces/IDisplayModule.hpp
@@ -9,6 +9,7 @@
 #include "IDrawable.hpp"
 #include "Event.hpp"
 #include "Sound.hpp"
+#include <memory>
 
 class IDisplayModule {
 public:

--- a/src/interfaces/IDisplayModule.hpp
+++ b/src/interfaces/IDisplayModule.hpp
@@ -10,14 +10,17 @@
 #include "Event.hpp"
 #include "Sound.hpp"
 #include <memory>
+#include "Window.hpp"
 
-class IDisplayModule {
-public:
-    virtual void draw(IDrawable) = 0;
-    virtual void display(void) = 0;
-    virtual void clear(void) = 0;
-    virtual Event getEvent(void) = 0;
-    virtual void handleSound(Sound) = 0;
-};
+class IDisplayModule
+{
+    public:
+        virtual void createWindow(const Window &window) = 0;
+        virtual void draw(const IDrawable &to_draw) = 0;
+        virtual void display(void) = 0;
+        virtual void clear(void) = 0;
+        virtual Event getEvent(void) = 0;
+        virtual void handleSound(const Sound &sound) = 0;
+};                                                                             
 
 std::unique_ptr<IDisplayModule> getDisplayModule();

--- a/src/interfaces/IDrawable.hpp
+++ b/src/interfaces/IDrawable.hpp
@@ -12,11 +12,14 @@
 
 class IDrawable {
 public:
-    IDrawable(
-        std::pair<float, float> scale,
-        float rotation,
-        std::pair<CLI_Color, CLI_Color> CLI_Color,
-        std::tuple<int, int, int, int> GUI_Color,
-        std::pair<int, int> position
-    ) = delete;
+    virtual std::pair<float, float> getScale(void) const = 0;
+    virtual float getRotation(void) const = 0;
+    virtual std::pair<CLI_Color, CLI_Color> getCLI_Color(void) const = 0;
+    virtual std::tuple<int, int, int, int> getGUI_Color(void) const = 0;
+    virtual std::pair<int, int> getPosition(void) const = 0;
+    virtual void setScale(std::pair<float, float> scale) = 0;
+    virtual void setRotation(float rotation) = 0;
+    virtual void setCLI_Color(std::pair<CLI_Color, CLI_Color> CLI_Color) = 0;
+    virtual void setGUI_Color(std::tuple<int, int, int, int> GUI_Color) = 0;
+    virtual void setPosition(std::pair<int, int> position) = 0;
 };

--- a/src/interfaces/IGameModule.hpp
+++ b/src/interfaces/IGameModule.hpp
@@ -13,12 +13,13 @@
 #include "Event.hpp"
 
 class IGameModule {
-public:
+public: 
     virtual bool update(float deltaTime) = 0;
-    virtual Window getWindow(void) = 0;
-    virtual std::vector<IDrawable> getDrawables(void) = 0;
-    virtual std::vector<Sound> getSound(void) = 0;
-    virtual bool event(Event) = 0;
+    virtual const Window &getWindow(void) = 0;
+    virtual const std::vector<std::unique_ptr<IDrawable>> &getDrawables(void) = 0;
+    virtual const std::vector<Sound> &getSound(void) = 0;
+    virtual bool event(const Event &events) = 0;
+    virtual std::vector<std::pair<std::string, int>> getScores(void) = 0;
 };
 
 std::unique_ptr<IGameModule> getGameModule();

--- a/src/interfaces/SDL/SDL2.cpp
+++ b/src/interfaces/SDL/SDL2.cpp
@@ -82,4 +82,46 @@ extern "C" {
     {
         SDL_RenderClear(renderer);
     }
+
+    void SDL2::SDL2_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
+    {
+        SDL_SetRenderDrawColor(renderer, r, g, b, a);
+    }
+
+    std::shared_ptr<TTF_Font> SDL2::TTF2_OpenFont(const char *file, int ptsize)
+    {
+        TTF_Font *rawFont = TTF_OpenFont(file, ptsize);
+        if (!rawFont)
+            return nullptr;
+        return std::shared_ptr<TTF_Font>(rawFont, TTF_CloseFont);
+    }
+
+    std::shared_ptr<SDL_Surface> SDL2::TTF2_RenderText_Blended(TTF_Font *font, const char *text, SDL_Color fg)
+    {
+        SDL_Surface *rawSurface = TTF_RenderText_Blended(font, text, fg);
+        if (!rawSurface)
+            return nullptr;
+        return std::shared_ptr<SDL_Surface>(rawSurface, SDL_FreeSurface);
+    }
+
+    std::shared_ptr<SDL_Texture> SDL2::SDL2_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface)
+    {
+        SDL_Texture *rawTexture = SDL_CreateTextureFromSurface(renderer, surface);
+        if (!rawTexture)
+            return nullptr;
+        return std::shared_ptr<SDL_Texture>(rawTexture, SDL_DestroyTexture);
+    }
+
+    std::shared_ptr<Mix_Chunk> SDL2::Mix2_LoadWAV(const char *file)
+    {
+        Mix_Chunk *rawChunk = Mix_LoadWAV(file);
+        if (!rawChunk)
+            return nullptr;
+        return std::shared_ptr<Mix_Chunk>(rawChunk, Mix_FreeChunk);
+    }
+
+    void SDL2::Mix2_PlayChannel(int channel, Mix_Chunk *chunk, int loops)
+    {
+        Mix_PlayChannel(channel, chunk, loops);
+    }
 }

--- a/src/interfaces/SDL/SDL2.cpp
+++ b/src/interfaces/SDL/SDL2.cpp
@@ -34,19 +34,28 @@ extern "C" {
         SDL_SetHint(name, value);
     }
 
-    SDL_Window *SDL2::SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
+    std::shared_ptr<SDL_Window> SDL2::SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
     {
-        return SDL_CreateWindow(title, x, y, w, h, flags);
+        SDL_Window *rawWindow = SDL_CreateWindow(title, x, y, w, h, flags);
+        if (!rawWindow)
+            return nullptr;
+        return std::shared_ptr<SDL_Window>(rawWindow, SDL_DestroyWindow);
     }
 
-    SDL_Renderer *SDL2::SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags)
+    std::shared_ptr<SDL_Renderer> SDL2::SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags)
     {
-        return SDL_CreateRenderer(window, index, flags);
+        SDL_Renderer *rawRenderer = SDL_CreateRenderer(window, index, flags);
+        if (!rawRenderer)
+            return nullptr;
+        return std::shared_ptr<SDL_Renderer>(rawRenderer, SDL_DestroyRenderer);
     }
 
-    SDL_Texture *SDL2::IMG2_LoadTexture(SDL_Renderer *renderer, const char *file)
+    std::shared_ptr<SDL_Texture> SDL2::IMG2_LoadTexture(SDL_Renderer *renderer, const char *file)
     {
-        return IMG_LoadTexture(renderer, file);
+        SDL_Texture *rawTexture = IMG_LoadTexture(renderer, file);
+        if (!rawTexture)
+            return nullptr;
+        return std::shared_ptr<SDL_Texture>(rawTexture, SDL_DestroyTexture);
     }
 
     void SDL2::SDL2_QueryTexture(SDL_Texture *texture, Uint32 *format, int *access, int *w, int *h)

--- a/src/interfaces/SDL/SDL2.cpp
+++ b/src/interfaces/SDL/SDL2.cpp
@@ -1,0 +1,76 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** SDL2
+*/
+
+#include "SDL2.hpp"
+#include <SDL2/SDL_image.h>
+
+extern "C" {
+    int SDL2::SDL2_Init(Uint32 flags)
+    {
+        return SDL_Init(flags);
+    }
+
+    void SDL2::SDL2_Quit(void)
+    {
+        SDL_Quit();
+    }
+
+    void SDL2::SDL2_DestroyRenderer(SDL_Renderer *renderer)
+    {
+        SDL_DestroyRenderer(renderer);
+    }
+
+    void SDL2::SDL2_DestroyWindow(SDL_Window *window)
+    {
+        SDL_DestroyWindow(window);
+    }
+
+    void SDL2::SDL2_SetHint(const char *name, const char *value)
+    {
+        SDL_SetHint(name, value);
+    }
+
+    SDL_Window *SDL2::SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
+    {
+        return SDL_CreateWindow(title, x, y, w, h, flags);
+    }
+
+    SDL_Renderer *SDL2::SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags)
+    {
+        return SDL_CreateRenderer(window, index, flags);
+    }
+
+    SDL_Texture *SDL2::IMG2_LoadTexture(SDL_Renderer *renderer, const char *file)
+    {
+        return IMG_LoadTexture(renderer, file);
+    }
+
+    void SDL2::SDL2_QueryTexture(SDL_Texture *texture, Uint32 *format, int *access, int *w, int *h)
+    {
+        SDL_QueryTexture(texture, format, access, w, h);
+    }
+
+    void SDL2::SDL2_RenderCopy(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *srcrect, const SDL_Rect *dstrect)
+    {
+        SDL_RenderCopy(renderer, texture, srcrect, dstrect);
+    }
+
+    void SDL2::SDL2_RenderPresent(SDL_Renderer *renderer)
+    {
+        SDL_RenderPresent(renderer);
+    }
+
+    int SDL2::SDL2_PollEvent(SDL_Event *event)
+    {
+        return SDL_PollEvent(event);
+    }
+
+    void SDL2::SDL2_RenderClear(SDL_Renderer *renderer)
+    {
+        SDL_RenderClear(renderer);
+    }
+}

--- a/src/interfaces/SDL/SDL2.hpp
+++ b/src/interfaces/SDL/SDL2.hpp
@@ -1,0 +1,28 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** SDL2
+*/
+
+#pragma once
+#include <SDL2/SDL.h>
+
+class SDL2
+{
+    public:
+        static int SDL2_Init(Uint32 flags);
+        static void SDL2_Quit(void);
+        static void SDL2_DestroyRenderer(SDL_Renderer *renderer);
+        static void SDL2_DestroyWindow(SDL_Window *window);
+        static void SDL2_SetHint(const char *name, const char *value);
+        static SDL_Window *SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags);
+        static SDL_Renderer *SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags);
+        static SDL_Texture *IMG2_LoadTexture(SDL_Renderer *renderer, const char *file);
+        static void SDL2_QueryTexture(SDL_Texture *texture, Uint32 *format, int *access, int *w, int *h);
+        static void SDL2_RenderCopy(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *srcrect, const SDL_Rect *dstrect);
+        static void SDL2_RenderPresent(SDL_Renderer *renderer);
+        static int SDL2_PollEvent(SDL_Event *event);
+        static void SDL2_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+        static void SDL2_RenderClear(SDL_Renderer *renderer);
+};

--- a/src/interfaces/SDL/SDL2.hpp
+++ b/src/interfaces/SDL/SDL2.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 #include <SDL2/SDL.h>
+#include <memory>
 
 class SDL2
 {
@@ -16,9 +17,9 @@ class SDL2
         static void SDL2_DestroyRenderer(SDL_Renderer *renderer);
         static void SDL2_DestroyWindow(SDL_Window *window);
         static void SDL2_SetHint(const char *name, const char *value);
-        static SDL_Window *SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags);
-        static SDL_Renderer *SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags);
-        static SDL_Texture *IMG2_LoadTexture(SDL_Renderer *renderer, const char *file);
+        static std::shared_ptr<SDL_Window> SDL2_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags);
+        static std::shared_ptr<SDL_Renderer> SDL2_CreateRenderer(SDL_Window *window, int index, Uint32 flags);
+        static std::shared_ptr<SDL_Texture> IMG2_LoadTexture(SDL_Renderer *renderer, const char *file);
         static void SDL2_QueryTexture(SDL_Texture *texture, Uint32 *format, int *access, int *w, int *h);
         static void SDL2_RenderCopy(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *srcrect, const SDL_Rect *dstrect);
         static void SDL2_RenderPresent(SDL_Renderer *renderer);

--- a/src/interfaces/SDL/SDL2.hpp
+++ b/src/interfaces/SDL/SDL2.hpp
@@ -8,6 +8,8 @@
 #pragma once
 #include <SDL2/SDL.h>
 #include <memory>
+#include <SDL2/SDL_ttf.h>
+#include <SDL2/SDL_mixer.h>
 
 class SDL2
 {
@@ -26,4 +28,11 @@ class SDL2
         static int SDL2_PollEvent(SDL_Event *event);
         static void SDL2_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
         static void SDL2_RenderClear(SDL_Renderer *renderer);
+
+        static std::shared_ptr<TTF_Font> TTF2_OpenFont(const char *file, int ptsize);
+        static std::shared_ptr<SDL_Surface> TTF2_RenderText_Blended(TTF_Font *font, const char *text, SDL_Color fg);
+        static std::shared_ptr<SDL_Texture> SDL2_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
+
+        static std::shared_ptr<Mix_Chunk> Mix2_LoadWAV(const char *file);
+        static void Mix2_PlayChannel(int channel, Mix_Chunk *chunk, int loops);
 };

--- a/src/interfaces/SDL/SDLDisplay.cpp
+++ b/src/interfaces/SDL/SDLDisplay.cpp
@@ -12,6 +12,7 @@
 #include <map>
 #include <Text.hpp>
 #include <Sprite.hpp>
+#include "SDL2.hpp"
 
 std::unique_ptr<IDisplayModule> getDisplayModule()
 {
@@ -24,14 +25,14 @@ void SDLDisplay::createWindow(const Window &window)
 
     rendererFlags = SDL_RENDERER_ACCELERATED;
     windowFlags = 0;
-    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+    if (SDL2::SDL2_Init(SDL_INIT_VIDEO) < 0)
         exit(1);
-    app.window = SDL_CreateWindow(window.title.c_str(),
+    app.window = SDL2::SDL2_CreateWindow(window.title.c_str(),
         SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
         window.size.first, window.size.second, windowFlags);
     if (!app.window)
         exit(1);
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+    SDL2::SDL2_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
     app.renderer = SDL_CreateRenderer(app.window, -1, rendererFlags);
     if (!app.renderer)
         exit(1);
@@ -43,31 +44,31 @@ void SDLDisplay::draw(const IDrawable &drawable)
     if (dynamic_cast<const Text *>(&drawable))
         return;
     Sprite sprite = dynamic_cast<const Sprite &>(drawable);
-    SDL_Texture *texture = IMG_LoadTexture(app.renderer, sprite.getGUI_Textures()[0].c_str());
+    SDL_Texture *texture = SDL2::IMG2_LoadTexture(app.renderer, sprite.getGUI_Textures()[0].c_str());
 
     dest.x = drawable.getPosition().first;
     dest.y = drawable.getPosition().second;
-    SDL_QueryTexture(texture, NULL, NULL, &dest.w, &dest.h);
+    SDL2::SDL2_QueryTexture(texture, NULL, NULL, &dest.w, &dest.h);
 
-    SDL_RenderCopy(app.renderer, texture, NULL, &dest);
+    SDL2::SDL2_RenderCopy(app.renderer, texture, NULL, &dest);
 }
 
 void SDLDisplay::display(void)
 {
-    SDL_RenderPresent(app.renderer);
+    SDL2::SDL2_RenderPresent(app.renderer);
 }
 
 void SDLDisplay::clear(void)
 {
-    SDL_SetRenderDrawColor(app.renderer, 0, 0, 0, 255);
-    SDL_RenderClear(app.renderer);
+    SDL2::SDL2_SetRenderDrawColor(app.renderer, 0, 0, 0, 255);
+    SDL2::SDL2_RenderClear(app.renderer);
 }
 
 Event SDLDisplay::getEvent(void)
 {
     SDL_Event event;
 
-    if (!SDL_PollEvent(&event))
+    if (!SDL2::SDL2_PollEvent(&event))
         return Event(Key::KeyCode::NONE, std::any());
     switch (event.type)
     {
@@ -98,9 +99,9 @@ void SDLDisplay::handleSound(const Sound &sound)
 
 SDLDisplay::~SDLDisplay()
 {
-    SDL_DestroyRenderer(app.renderer);
-    SDL_DestroyWindow(app.window);
-    SDL_Quit();
+    SDL2::SDL2_DestroyRenderer(app.renderer);
+    SDL2::SDL2_DestroyWindow(app.window);
+    SDL2::SDL2_Quit();
 }
 
 Event SDLDisplay::getEventKeyBoard(SDL_Event &e, Event::KeyStatus isDown)

--- a/src/interfaces/SDL/SDLDisplay.cpp
+++ b/src/interfaces/SDL/SDLDisplay.cpp
@@ -33,7 +33,7 @@ void SDLDisplay::createWindow(const Window &window)
     if (!app.window)
         exit(1);
     SDL2::SDL2_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-    app.renderer = SDL_CreateRenderer(app.window, -1, rendererFlags);
+    app.renderer = SDL2::SDL2_CreateRenderer(app.window.get(), -1, rendererFlags);
     if (!app.renderer)
         exit(1);
 }
@@ -44,24 +44,24 @@ void SDLDisplay::draw(const IDrawable &drawable)
     if (dynamic_cast<const Text *>(&drawable))
         return;
     Sprite sprite = dynamic_cast<const Sprite &>(drawable);
-    SDL_Texture *texture = SDL2::IMG2_LoadTexture(app.renderer, sprite.getGUI_Textures()[0].c_str());
+    std::shared_ptr<SDL_Texture> texture = SDL2::IMG2_LoadTexture(app.renderer.get(), sprite.getGUI_Textures()[0].c_str());
 
     dest.x = drawable.getPosition().first;
     dest.y = drawable.getPosition().second;
-    SDL2::SDL2_QueryTexture(texture, NULL, NULL, &dest.w, &dest.h);
+    SDL2::SDL2_QueryTexture(texture.get(), NULL, NULL, &dest.w, &dest.h);
 
-    SDL2::SDL2_RenderCopy(app.renderer, texture, NULL, &dest);
+    SDL2::SDL2_RenderCopy(app.renderer.get(), texture.get(), NULL, &dest);
 }
 
 void SDLDisplay::display(void)
 {
-    SDL2::SDL2_RenderPresent(app.renderer);
+    SDL2::SDL2_RenderPresent(app.renderer.get());
 }
 
 void SDLDisplay::clear(void)
 {
-    SDL2::SDL2_SetRenderDrawColor(app.renderer, 0, 0, 0, 255);
-    SDL2::SDL2_RenderClear(app.renderer);
+    SDL2::SDL2_SetRenderDrawColor(app.renderer.get(), 0, 0, 0, 255);
+    SDL2::SDL2_RenderClear(app.renderer.get());
 }
 
 Event SDLDisplay::getEvent(void)
@@ -99,8 +99,8 @@ void SDLDisplay::handleSound(const Sound &sound)
 
 SDLDisplay::~SDLDisplay()
 {
-    SDL2::SDL2_DestroyRenderer(app.renderer);
-    SDL2::SDL2_DestroyWindow(app.window);
+    SDL2::SDL2_DestroyRenderer(app.renderer.get());
+    SDL2::SDL2_DestroyWindow(app.window.get());
     SDL2::SDL2_Quit();
 }
 

--- a/src/interfaces/SDL/SDLDisplay.cpp
+++ b/src/interfaces/SDL/SDLDisplay.cpp
@@ -6,8 +6,255 @@
 */
 
 #include "SDLDisplay.hpp"
+#include "Window.hpp"
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
+#include <map>
+#include <Text.hpp>
+#include <Sprite.hpp>
 
 std::unique_ptr<IDisplayModule> getDisplayModule()
 {
     return std::make_unique<SDLDisplay>();
+}
+
+void SDLDisplay::createWindow(const Window &window)
+{
+    int rendererFlags, windowFlags;
+
+    rendererFlags = SDL_RENDERER_ACCELERATED;
+    windowFlags = 0;
+    if (SDL_Init(SDL_INIT_VIDEO) < 0)
+        exit(1);
+    app.window = SDL_CreateWindow(window.title.c_str(),
+        SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+        window.size.first, window.size.second, windowFlags);
+    if (!app.window)
+        exit(1);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+    app.renderer = SDL_CreateRenderer(app.window, -1, rendererFlags);
+    if (!app.renderer)
+        exit(1);
+}
+
+void SDLDisplay::draw(const IDrawable &drawable)
+{
+    SDL_Rect dest;
+    if (dynamic_cast<const Text *>(&drawable))
+        return;
+    Sprite sprite = dynamic_cast<const Sprite &>(drawable);
+    SDL_Texture *texture = IMG_LoadTexture(app.renderer, sprite.getGUI_Textures()[0].c_str());
+
+    dest.x = drawable.getPosition().first;
+    dest.y = drawable.getPosition().second;
+    SDL_QueryTexture(texture, NULL, NULL, &dest.w, &dest.h);
+
+    SDL_RenderCopy(app.renderer, texture, NULL, &dest);
+}
+
+void SDLDisplay::display(void)
+{
+    SDL_RenderPresent(app.renderer);
+}
+
+void SDLDisplay::clear(void)
+{
+    SDL_SetRenderDrawColor(app.renderer, 0, 0, 0, 255);
+    SDL_RenderClear(app.renderer);
+}
+
+Event SDLDisplay::getEvent(void)
+{
+    SDL_Event event;
+
+    if (!SDL_PollEvent(&event))
+        return Event(Key::KeyCode::NONE, std::any());
+    switch (event.type)
+    {
+        case SDL_KEYDOWN:
+            return getEventKeyBoard(event, Event::KeyStatus::KEY_PRESSED);
+        case SDL_KEYUP:
+            return getEventKeyBoard(event, Event::KeyStatus::KEY_RELEASED);
+        case SDL_MOUSEMOTION:
+            LastMouseX = event.motion.x;
+            LastMouseY = event.motion.y;
+            return Event(Key::KeyCode::MOUSE_MOVE, Event::MousePos{event.motion.x, event.motion.y});
+        case SDL_MOUSEBUTTONDOWN:
+            return getEventMouse(event, Event::KeyStatus::KEY_PRESSED);
+        case SDL_MOUSEBUTTONUP:
+            return getEventMouse(event, Event::KeyStatus::KEY_RELEASED);
+        case SDL_MOUSEWHEEL:
+            return Event(Key::KeyCode::MOUSE_SCROLL, Event::MouseStatusScroll{Event::MousePos{LastMouseX, LastMouseY}, (float)event.wheel.y});
+        default:
+            return getEvent();
+            break;
+    }
+}
+
+void SDLDisplay::handleSound(const Sound &sound)
+{
+    (void)sound;
+}
+
+SDLDisplay::~SDLDisplay()
+{
+    SDL_DestroyRenderer(app.renderer);
+    SDL_DestroyWindow(app.window);
+    SDL_Quit();
+}
+
+Event SDLDisplay::getEventKeyBoard(SDL_Event &e, Event::KeyStatus isDown)
+{
+    switch (e.key.keysym.sym)
+    {
+        case SDLK_a:
+            return Event(Key::KeyCode::KEY_A, isDown);
+        case SDLK_b:
+            return Event(Key::KeyCode::KEY_B, isDown);
+        case SDLK_c:
+            return Event(Key::KeyCode::KEY_C, isDown);
+        case SDLK_d:
+            return Event(Key::KeyCode::KEY_D, isDown);
+        case SDLK_e:
+            return Event(Key::KeyCode::KEY_E, isDown);
+        case SDLK_f:
+            return Event(Key::KeyCode::KEY_F, isDown);
+        case SDLK_g:
+            return Event(Key::KeyCode::KEY_G, isDown);
+        case SDLK_h:
+            return Event(Key::KeyCode::KEY_H, isDown);
+        case SDLK_i:
+            return Event(Key::KeyCode::KEY_I, isDown);
+        case SDLK_j:
+            return Event(Key::KeyCode::KEY_J, isDown);
+        case SDLK_k:
+            return Event(Key::KeyCode::KEY_K, isDown);
+        case SDLK_l:
+            return Event(Key::KeyCode::KEY_L, isDown);
+        case SDLK_m:
+            return Event(Key::KeyCode::KEY_M, isDown);
+        case SDLK_n:
+            return Event(Key::KeyCode::KEY_N, isDown);
+        case SDLK_o:
+            return Event(Key::KeyCode::KEY_O, isDown);
+        case SDLK_p:
+            return Event(Key::KeyCode::KEY_P, isDown);
+        case SDLK_q:
+            return Event(Key::KeyCode::KEY_Q, isDown);
+        case SDLK_r:
+            return Event(Key::KeyCode::KEY_R, isDown);
+        case SDLK_s:
+            return Event(Key::KeyCode::KEY_S, isDown);
+        case SDLK_t:
+            return Event(Key::KeyCode::KEY_T, isDown);
+        case SDLK_u:
+            return Event(Key::KeyCode::KEY_U, isDown);
+        case SDLK_v:
+            return Event(Key::KeyCode::KEY_V, isDown);
+        case SDLK_w:
+            return Event(Key::KeyCode::KEY_W, isDown);
+        case SDLK_x:
+            return Event(Key::KeyCode::KEY_X, isDown);
+        case SDLK_y:
+            return Event(Key::KeyCode::KEY_Y, isDown);
+        case SDLK_z:
+            return Event(Key::KeyCode::KEY_Z, isDown);
+        case SDLK_0:
+            return Event(Key::KeyCode::KEY_0, isDown);
+        case SDLK_1:
+            return Event(Key::KeyCode::KEY_1, isDown);
+        case SDLK_2:
+            return Event(Key::KeyCode::KEY_2, isDown);
+        case SDLK_3:
+            return Event(Key::KeyCode::KEY_3, isDown);
+        case SDLK_4:
+            return Event(Key::KeyCode::KEY_4, isDown);
+        case SDLK_5:
+            return Event(Key::KeyCode::KEY_5, isDown);
+        case SDLK_6:
+            return Event(Key::KeyCode::KEY_6, isDown);
+        case SDLK_7:
+            return Event(Key::KeyCode::KEY_7, isDown);
+        case SDLK_8:
+            return Event(Key::KeyCode::KEY_8, isDown);
+        case SDLK_9:
+            return Event(Key::KeyCode::KEY_9, isDown);
+        case SDLK_SPACE:
+            return Event(Key::KeyCode::SPACE, isDown);
+        case SDLK_RETURN:
+            return Event(Key::KeyCode::ENTER, isDown);
+        case SDLK_TAB:
+            return Event(Key::KeyCode::TAB, isDown);
+        case SDLK_ESCAPE:
+            return Event(Key::KeyCode::ECHAP, isDown);
+        case SDLK_DELETE:
+            return Event(Key::KeyCode::SUPPR, isDown);
+        case SDLK_F1:
+            return Event(Key::KeyCode::FUNCTION_1, isDown);
+        case SDLK_F2:
+            return Event(Key::KeyCode::FUNCTION_2, isDown);
+        case SDLK_F3:
+            return Event(Key::KeyCode::FUNCTION_3, isDown);
+        case SDLK_F4:
+            return Event(Key::KeyCode::FUNCTION_4, isDown);
+        case SDLK_F5:
+            return Event(Key::KeyCode::FUNCTION_5, isDown);
+        case SDLK_F6:
+            return Event(Key::KeyCode::FUNCTION_6, isDown);
+        case SDLK_F7:
+            return Event(Key::KeyCode::FUNCTION_7, isDown);
+        case SDLK_F8:
+            return Event(Key::KeyCode::FUNCTION_8, isDown);
+        case SDLK_F9:
+            return Event(Key::KeyCode::FUNCTION_9, isDown);
+        case SDLK_F10:
+            return Event(Key::KeyCode::FUNCTION_10, isDown);
+        case SDLK_F11:
+            return Event(Key::KeyCode::FUNCTION_11, isDown);
+        case SDLK_F12:
+            return Event(Key::KeyCode::FUNCTION_12, isDown);
+        case SDLK_LEFT:
+            return Event(Key::KeyCode::LEFT, isDown);
+        case SDLK_UP:
+            return Event(Key::KeyCode::UP, isDown);
+        case SDLK_RIGHT:
+            return Event(Key::KeyCode::RIGHT, isDown);
+        case SDLK_DOWN:
+            return Event(Key::KeyCode::DOWN, isDown);
+        case SDLK_LSHIFT:
+            return Event(Key::KeyCode::L_SHIFT, isDown);
+        case SDLK_RSHIFT:
+            return Event(Key::KeyCode::R_SHIFT, isDown);
+        case SDLK_LCTRL:
+            return Event(Key::KeyCode::L_CONTROL, isDown);
+        case SDLK_RCTRL:
+            return Event(Key::KeyCode::R_CONTROL, isDown);
+        case SDLK_LALT:
+            return Event(Key::KeyCode::ALT, isDown);
+        case SDLK_RALT:
+            return Event(Key::KeyCode::ALTGR, isDown);
+        default:
+            return getEvent();
+            break;
+    }
+}
+
+Event SDLDisplay::getEventMouse(SDL_Event &e, Event::KeyStatus isDown)
+{
+    switch (e.button.button)
+    {
+        case SDL_BUTTON_LEFT:
+            return Event(Key::KeyCode::MOUSE_LEFT, Event::MouseStatusClick{Event::MousePos{e.button.x, e.button.y}, isDown});
+        case SDL_BUTTON_MIDDLE:
+            return Event(Key::KeyCode::MOUSE_MIDDLE, Event::MouseStatusClick{Event::MousePos{e.button.x, e.button.y}, isDown});
+        case SDL_BUTTON_RIGHT:
+            return Event(Key::KeyCode::MOUSE_RIGHT, Event::MouseStatusClick{Event::MousePos{e.button.x, e.button.y}, isDown});
+        case SDL_BUTTON_X1:
+            return Event(Key::KeyCode::MOUSE_BUTTON_4, Event::MouseStatusClick{Event::MousePos{e.button.x, e.button.y}, isDown});
+        case SDL_BUTTON_X2:
+            return Event(Key::KeyCode::MOUSE_BUTTON_5, Event::MouseStatusClick{Event::MousePos{e.button.x, e.button.y}, isDown});
+        default:
+            return getEvent();
+            break;
+    }
 }

--- a/src/interfaces/SDL/SDLDisplay.hpp
+++ b/src/interfaces/SDL/SDLDisplay.hpp
@@ -7,17 +7,31 @@
 
 #pragma once
 #include "IDisplayModule.hpp"
+#include "Window.hpp"
 #include <memory>
+#include <SDL2/SDL.h>
 
 std::unique_ptr<IDisplayModule> getDisplayModule();
 
 class SDLDisplay : public IDisplayModule
 {
 public:
-    void draw(IDrawable) override;
-    void display(void) override;
+    void createWindow(const Window &window) override;
     void clear(void) override;
+    void draw(const IDrawable &to_draw) override;
+    void display(void) override;
     Event getEvent(void) override;
-    void handleSound(Sound) override;
+    void handleSound(const Sound &sound) override;
+    ~SDLDisplay();
+private:
+    Event getEventKeyBoard(SDL_Event &e, Event::KeyStatus isDown);
+    Event getEventMouse(SDL_Event &e, Event::KeyStatus isDown);
+    typedef struct {
+        SDL_Renderer *renderer;
+        SDL_Window *window;
+    } App;
+
+    int LastMouseX, LastMouseY;
+    App app;
 };
 

--- a/src/interfaces/SDL/SDLDisplay.hpp
+++ b/src/interfaces/SDL/SDLDisplay.hpp
@@ -8,8 +8,12 @@
 #pragma once
 #include "IDisplayModule.hpp"
 #include "Window.hpp"
+#include "Text.hpp"
+#include "Sprite.hpp"
 #include <memory>
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_mixer.h>
+#include <map>
 
 std::unique_ptr<IDisplayModule> getDisplayModule();
 
@@ -26,13 +30,17 @@ public:
 private:
     Event getEventKeyBoard(SDL_Event &e, Event::KeyStatus isDown);
     Event getEventMouse(SDL_Event &e, Event::KeyStatus isDown);
+
+    void drawText(const Text &txt);
+    void drawSprite(const Sprite &sprite);
     
     typedef struct {
         std::shared_ptr<SDL_Renderer> renderer;
         std::shared_ptr<SDL_Window> window;
     } App;
 
+    std::map<std::string, std::pair<std::shared_ptr<Mix_Chunk>, int>> musics;
+
     int LastMouseX, LastMouseY;
     App app;
 };
-

--- a/src/interfaces/SDL/SDLDisplay.hpp
+++ b/src/interfaces/SDL/SDLDisplay.hpp
@@ -26,9 +26,10 @@ public:
 private:
     Event getEventKeyBoard(SDL_Event &e, Event::KeyStatus isDown);
     Event getEventMouse(SDL_Event &e, Event::KeyStatus isDown);
+    
     typedef struct {
-        SDL_Renderer *renderer;
-        SDL_Window *window;
+        std::shared_ptr<SDL_Renderer> renderer;
+        std::shared_ptr<SDL_Window> window;
     } App;
 
     int LastMouseX, LastMouseY;

--- a/src/interfaces/Sprite.hpp
+++ b/src/interfaces/Sprite.hpp
@@ -1,0 +1,42 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** Sprite
+*/
+
+#pragma once
+#include "IDrawable.hpp"
+#include <vector>
+#include <string>
+#include <tuple>
+
+class Sprite : public IDrawable {
+public:
+    std::vector<std::string> getGUI_Textures(void) const { return GUI_Textures; };
+    std::vector<char[2]> getCLI_Textures(void) const { return CLI_Textures; };
+    float getAnimationTime(void) const { return animationTime; };
+    void setGUI_Textures(std::vector<std::string> GUI_Textures) { this->GUI_Textures = GUI_Textures; };
+    void setCLI_Textures(std::vector<char[2]> CLI_Textures) { this->CLI_Textures = CLI_Textures; };
+    void setAnimationTime(float animationTime) { this->animationTime = animationTime; };
+    
+    std::pair<float, float> getScale(void) const override { return scale; };
+    float getRotation(void) const override { return rotation; };
+    std::pair<CLI_Color, CLI_Color> getCLI_Color(void) const override { return CLI_color; };
+    std::tuple<int, int, int, int> getGUI_Color(void) const override { return GUI_color; };
+    std::pair<int, int> getPosition(void) const override { return position; };
+    void setScale(std::pair<float, float> scale) override { this->scale = scale; };
+    void setRotation(float rotation) override { this->rotation = rotation; };
+    void setCLI_Color(std::pair<CLI_Color, CLI_Color> CLI_Color) override { this->CLI_color = CLI_Color; };
+    void setGUI_Color(std::tuple<int, int, int, int> GUI_Color) override { this->GUI_color = GUI_Color; };
+    void setPosition(std::pair<int, int> position) override { this->position = position; };
+private:
+    std::vector<std::string> GUI_Textures;
+	std::vector<char[2]>  CLI_Textures;
+	float animationTime;
+    std::pair<float, float> scale;
+	float rotation;
+	std::pair<CLI_Color, CLI_Color> CLI_color;
+	std::tuple<int, int, int, int> GUI_color;
+	std::pair<int, int> position;
+};

--- a/src/interfaces/Sprite.hpp
+++ b/src/interfaces/Sprite.hpp
@@ -9,15 +9,14 @@
 #include "IDrawable.hpp"
 #include <vector>
 #include <string>
-#include <tuple>
 
 class Sprite : public IDrawable {
 public:
     std::vector<std::string> getGUI_Textures(void) const { return GUI_Textures; };
-    std::vector<char[2]> getCLI_Textures(void) const { return CLI_Textures; };
+    const std::vector<std::string> &getCLI_Textures() const { return CLI_Textures; }
     float getAnimationTime(void) const { return animationTime; };
     void setGUI_Textures(std::vector<std::string> GUI_Textures) { this->GUI_Textures = GUI_Textures; };
-    void setCLI_Textures(std::vector<char[2]> CLI_Textures) { this->CLI_Textures = CLI_Textures; };
+    void setCLI_Textures(std::vector<std::string> CLI_Textures) { this->CLI_Textures = CLI_Textures; }
     void setAnimationTime(float animationTime) { this->animationTime = animationTime; };
     
     std::pair<float, float> getScale(void) const override { return scale; };
@@ -32,7 +31,7 @@ public:
     void setPosition(std::pair<int, int> position) override { this->position = position; };
 private:
     std::vector<std::string> GUI_Textures;
-	std::vector<char[2]>  CLI_Textures;
+	std::vector<std::string> CLI_Textures;
 	float animationTime;
     std::pair<float, float> scale;
 	float rotation;

--- a/src/interfaces/Text.hpp
+++ b/src/interfaces/Text.hpp
@@ -1,0 +1,41 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** Text
+*/
+
+#pragma once
+#include "IDrawable.hpp"
+#include <vector>
+#include <string>
+#include <tuple>
+
+class Text : public IDrawable
+{
+public:
+    std::string getFontPath(void) const { return fontPath; };
+    std::string getStr(void) const { return str; };
+    void setFontPath(std::string fontPath) { this->fontPath = fontPath; };
+    void setStr(std::string str) { this->str = str; };
+    
+    std::pair<float, float> getScale(void) const override { return scale; };
+    float getRotation(void) const override { return rotation; };
+    std::pair<CLI_Color, CLI_Color> getCLI_Color(void) const override { return CLI_color; };
+    std::tuple<int, int, int, int> getGUI_Color(void) const override { return GUI_color; };
+    std::pair<int, int> getPosition(void) const override { return position; };
+    void setScale(std::pair<float, float> scale) override { this->scale = scale; };
+    void setRotation(float rotation) override { this->rotation = rotation; };
+    void setCLI_Color(std::pair<CLI_Color, CLI_Color> CLI_Color) override { this->CLI_color = CLI_Color; };
+    void setGUI_Color(std::tuple<int, int, int, int> GUI_Color) override { this->GUI_color = GUI_Color; };
+    void setPosition(std::pair<int, int> position) override { this->position = position; };
+private:
+    std::string fontPath;
+	std::string str;
+
+    std::pair<float, float> scale;
+	float rotation;
+	std::pair<CLI_Color, CLI_Color> CLI_color;
+	std::tuple<int, int, int, int> GUI_color;
+	std::pair<int, int> position;
+};


### PR DESCRIPTION
Updates to the `Makefile` to support SDL2, modifications to the `IDrawable` and `IGameModule` interfaces, and the addition of new SDL2Display

### Makefile Updates:
* Updated `FLAGS` to include new directories and added `FLAGS_SDL` for SDL2-specific flags.
* Added a new target `graphicals` to compile SDL2-related source files.

### Interface and Event Handling Improvements:
* Added new enums and structs in `Event` class to handle mouse events.
* Updated `IDrawable` interface to include getter and setter methods for drawable properties.
* Modified `IGameModule` interface to use `std::unique_ptr` for drawable objects and added a method to get scores.

### SDL2 Integration:
* Added `SDL2` class with static methods for SDL2 initialization and resource management. 
* Implemented `SDLDisplay` class to handle window creation, rendering, and event processing using SDL2.

### Drawable Object Enhancements:
* Introduced `Sprite` and `Text` classes inheriting from `IDrawable` to manage graphical and textual elements.