### PR TITLE
✨ NCurseDisplay class (missing getEvents for now)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,14 @@ FLAGS_SDL = $(FLAGS_LIB) -lSDL2 -lSDL2_image \
 			-I./include \
 			-I./src/core \
 
+FLAGS_NCURSE = $(FLAGS_LIB) \
+			-I./src/interfaces \
+			-I./include \
+			-I./src/core \
+
 FLAGS_TEST = $(FLAGS) -lcriterion --coverage \
 
 FLAGS_LIB = -std=c++20 -Wall -Wextra -Werror
-
-CXXFLAGS += -I/usr/include/SDL2 -I./src/interfaces -I./include -I./src/core
-LDFLAGS += -lSDL2 -lSDL2_ttf -lSDL2_image -lSDL2_mixer
 
 # ============= NAMES ============= #
 
@@ -59,6 +61,8 @@ NAME	=	arcade
 
 NAME_SDL = lib/arcade_sdl2.so
 
+NAME_NCURSE = lib/arcade_ncurse.so
+
 # ============= SOURCES ============= #
 
 SRC_LIB	=	\
@@ -67,8 +71,11 @@ SRC_MAIN	=	main.cpp \
 
 SRC	= 	src/core/Core.cpp \
 
-SRC_SDL = src/interfaces/SDL/SDLDisplay.cpp \
-		 src/interfaces/SDL/SDL2.cpp \
+SRC_SDL	=	src/interfaces/SDL/SDLDisplay.cpp \
+			src/interfaces/SDL/SDL2.cpp \
+
+SRC_NCURSE	=	src/displays/NCurse/NCurseDisplay.cpp \
+				src/displays/NCurse/NCurseWrapper.cpp
 
 SRC_TESTS	= 	tests/test_1.cpp \
 
@@ -84,6 +91,7 @@ $(NAME_LIB): $(OBJ)
 
 graphicals:
 	$(COMPILER) -o $(NAME_SDL) -shared -fPIC $(SRC_SDL) $(FLAGS_SDL)
+	$(COMPILER) -o $(NAME_NCURSE) -shared -fPIC $(SRC_NCURSE) $(FLAGS_NCURSE)
 
 # ============= CLEANS ============= #
 

--- a/src/displays/NCurse/NCurseDisplay.cpp
+++ b/src/displays/NCurse/NCurseDisplay.cpp
@@ -1,0 +1,63 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** NCurseDisplay
+*/
+
+#include "NCurseDisplay.hpp"
+
+NCurseDisplay::NCurseDisplay()
+{
+    _window = nullptr;
+}
+
+NCurseDisplay::~NCurseDisplay()
+{
+    if (_window)
+        _window->~NCurseWrapper();
+}
+
+void NCurseDisplay::createWindow(const Window &window)
+{
+    _window = std::make_unique<NCurseWrapper>(window.size.second, window.size.first);
+}
+
+void NCurseDisplay::draw(const IDrawable &to_draw)
+{
+    Sprite sprite;
+    Text text;
+
+    try {
+        sprite = dynamic_cast<const Sprite &>(to_draw);
+        _window->print(sprite.getPosition().first, sprite.getPosition().second, sprite.getCLI_Textures()[0]);
+    } catch (std::bad_cast &e) {
+        text = dynamic_cast<const Text &>(to_draw);
+        _window->print(text.getPosition().first, text.getPosition().second, text.getStr());
+    }
+}
+
+void NCurseDisplay::display(void)
+{
+    _window->refresh();
+}
+
+void NCurseDisplay::clear(void)
+{
+    _window->clear();
+}
+
+Event NCurseDisplay::getEvent(void)
+{
+    int ch = getch();
+    Event event(Key::KEY_A, 0);
+
+    std::cout << "Key pressed: " << ch << std::endl;
+
+    return event;
+}
+
+void NCurseDisplay::handleSound(const Sound &sound)
+{
+    (void)sound;
+}

--- a/src/displays/NCurse/NCurseDisplay.hpp
+++ b/src/displays/NCurse/NCurseDisplay.hpp
@@ -1,0 +1,30 @@
+/*
+** EPITECH PROJECT, 2025
+** Arcade
+** File description:
+** NCurseDisplay
+*/
+
+#pragma once
+#include <iostream>
+
+#include "IDisplayModule.hpp"
+#include "NCurseWrapper.hpp"
+#include "Sprite.hpp"
+#include "Text.hpp"
+
+class NCurseDisplay : public IDisplayModule {
+public:
+    NCurseDisplay();
+    ~NCurseDisplay() override;
+
+    void createWindow(const Window &window) override;
+    void draw(const IDrawable &to_draw) override;
+    void display(void) override;
+    void clear(void) override;
+    Event getEvent(void) override;
+    void handleSound(const Sound &sound) override;
+
+private:
+    std::unique_ptr<NCurseWrapper> _window;
+};


### PR DESCRIPTION
This pull request introduces a new display module using the Ncurses library and updates the `Makefile` to support it. The most important changes include adding new flags, names, and sources for the Ncurses display, as well as implementing the `NCurseDisplay` class.

### Makefile updates:

* Added `FLAGS_NCURSE` for compiling the Ncurses display module.
* Added `NAME_NCURSE` for the Ncurses shared library.
* Added `SRC_NCURSE` for the source files of the Ncurses display module.
* Updated the `graphicals` rule to compile the Ncurses display module.

### Ncurses display module implementation:

* Implemented the `NCurseDisplay` class in `src/displays/NCurse/NCurseDisplay.cpp` with methods for window creation, drawing, displaying, clearing, event handling, and sound handling.
* Defined the `NCurseDisplay` class in `src/displays/NCurse/NCurseDisplay.hpp` with appropriate member variables and method declarations.