### PR TITLE
:bug: Fix bad alloc

### DIFF
--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -119,7 +119,6 @@ void Core::Core::nextDisplay(int i)
 bool Core::Core::handleEventLibs(Event &event)
 {
     try {
-        printf("Key: %d\n", std::any_cast<Event::KeyStatus>(event.value));
         if (std::any_cast<Event::KeyStatus>(event.value) != Event::KeyStatus::KEY_RELEASED)
             return false;
     } catch (const std::bad_any_cast& e) {}
@@ -193,7 +192,6 @@ void Core::Core::openGame(const std::string &gameLibPath)
     auto module = createModule();
     _game = std::move(module);
     refreshLibs();
-    printf("Game loaded: %s\n", gameLibPath.c_str());
 }
 
 void Core::Core::openDisplay(const std::string &displayLibPath)
@@ -214,7 +212,6 @@ void Core::Core::openDisplay(const std::string &displayLibPath)
     auto module = createModule();
     _display = std::move(module);
     _display->createWindow(_game->getWindow());
-    printf("Game loaded: %s\n", displayLibPath.c_str());
 }
 
 void Core::Core::setIdisplay(const std::string &displayLibPath)

--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -91,45 +91,48 @@ Core::StateCore Core::Core::update()
     return StateCore::NONE;
 }
 
-bool Core::Core::handleEventLibs(const Event &event)
+void Core::Core::nextGame(int i)
+{
+    if (_gameLibs.size() == 0)
+        return;
+    _gameIndex = (_gameIndex + i) % _gameLibs.size();
+    if (_gameLibs[_gameIndex] == "Menu") {
+        _game = std::make_unique<CoreMenu>(*this);
+        refreshLibs();
+    } else
+        openGame(_gameLibs[_gameIndex]);
+    skipNext = true;
+}
+
+void Core::Core::nextDisplay(int i)
+{
+    if (_displayLibs.size() == 0)
+        return;
+    _displayIndex = (_displayIndex + i) % _displayLibs.size();
+    openDisplay(_displayLibs[_displayIndex]);
+    skipNext = true;
+}
+
+bool Core::Core::handleEventLibs(Event &event)
 {
     try {
+        printf("Key: %d\n", std::any_cast<Event::KeyStatus>(event.value));
         if (std::any_cast<Event::KeyStatus>(event.value) != Event::KeyStatus::KEY_RELEASED)
             return false;
     } catch (const std::bad_any_cast& e) {}
+
     switch (event.key) {
         case Key::KeyCode::KEY_P:
-            if (_gameLibs.size() == 0)
-                break;
-            _gameIndex = (_gameIndex + 1) % _gameLibs.size();
-            if (_gameLibs[_gameIndex] == "Menu") {
-                _game = std::make_unique<CoreMenu>(*this);
-                refreshLibs();
-            } else
-                openGame(_gameLibs[_gameIndex]);
+            nextGame(1);
             break;
         case Key::KeyCode::KEY_O:
-            if (_gameLibs.size() == 0)
-                break;
-            _gameIndex =(_gameIndex - 1) % _gameLibs.size();
-            if (_gameLibs[_gameIndex] == "Menu") {
-                _game = std::make_unique<CoreMenu>(*this);
-                refreshLibs();
-            } else
-                openGame(_gameLibs[_gameIndex]);
+            nextGame(-1);
             break;
         case Key::KeyCode::KEY_I:
-            if (_displayLibs.size() == 0)
-                break;
-            openDisplay(_displayLibs[++_displayIndex % _displayLibs.size()]);
+            nextDisplay(1);
             break;
         case Key::KeyCode::KEY_U:
-            if (_displayLibs.size() == 0)
-                break;
-            if (_displayIndex == 0)
-                openDisplay(_displayLibs[_displayLibs.size() - 1]);
-            else
-                openDisplay(_displayLibs[--_displayIndex % _displayLibs.size()]);
+            nextDisplay(-1);
             break;
         default:
             return false;
@@ -146,6 +149,11 @@ Core::StateCore Core::Core::events()
             return StateCore::EXIT_TO_MENU;
         if (event.key == Key::KeyCode::FUNCTION_4)
             return StateCore::EXIT;
+        if (skipNext) {
+            skipNext = false;
+            event = _display->getEvent();
+            continue;
+        }
         handleEventLibs(event);
         if (_game->event(event))
             return StateCore::EXIT_TO_MENU;
@@ -182,6 +190,7 @@ void Core::Core::openGame(const std::string &gameLibPath)
     auto module = createModule();
     _game = std::move(module);
     refreshLibs();
+    printf("Game loaded: %s\n", gameLibPath.c_str());
 }
 
 void Core::Core::openDisplay(const std::string &displayLibPath)
@@ -202,6 +211,7 @@ void Core::Core::openDisplay(const std::string &displayLibPath)
     auto module = createModule();
     _display = std::move(module);
     _display->createWindow(_game->getWindow());
+    printf("Game loaded: %s\n", displayLibPath.c_str());
 }
 
 void Core::Core::setIdisplay(const std::string &displayLibPath)

--- a/src/core/Core.cpp
+++ b/src/core/Core.cpp
@@ -108,7 +108,10 @@ void Core::Core::nextDisplay(int i)
 {
     if (_displayLibs.size() == 0)
         return;
-    _displayIndex = (_displayIndex + i) % _displayLibs.size();
+    if (_displayIndex == 0 && i == -1)
+        _displayIndex = _displayLibs.size() - 1;
+    else
+        _displayIndex = (_displayIndex + i) % _displayLibs.size();
     openDisplay(_displayLibs[_displayIndex]);
     skipNext = true;
 }

--- a/src/core/Core.hpp
+++ b/src/core/Core.hpp
@@ -44,6 +44,8 @@ public:
     void closeDisplay();
     void openDisplay(const std::string &displayLibPath);
     void setIdisplay(const std::string &displayLibPath);
+    void nextDisplay(int i);
+    void nextGame(int i);
 private:
     void openGame(const std::string &gameLibPath);
     void closeGame();
@@ -61,8 +63,9 @@ private:
     std::chrono::steady_clock::time_point lastFrameTime;
     int _displayIndex = 0;
     int _gameIndex = 0;
+    bool skipNext = false;
 
-    bool handleEventLibs(const Event &event);
+    bool handleEventLibs(Event &event);
 };
 
 class Error : public std::exception {

--- a/src/displays/SFML/SFMLDisplay.cpp
+++ b/src/displays/SFML/SFMLDisplay.cpp
@@ -167,7 +167,7 @@ Event SFMLDisplay::getEventKeyBoard(sf::Event &e, Event::KeyStatus isDown)
 {
     auto it = keyboardMap.find(e.key.code);
     if (it != keyboardMap.end()) {
-        return Event(it->second, isDown);
+        return Event(it->second, std::any(isDown));
     }
     return getEvent();
 }
@@ -176,7 +176,7 @@ Event SFMLDisplay::getEventMouse(sf::Event &e, Event::KeyStatus isDown)
 {
     auto it = mouseMap.find(e.mouseButton.button);
     if (it != mouseMap.end()) {
-        return Event(it->second, Event::MouseStatusClick{Event::MousePos{e.mouseButton.x, e.mouseButton.y}, isDown});
+        return Event(it->second, std::any(Event::MouseStatusClick{Event::MousePos{e.mouseButton.x, e.mouseButton.y}, isDown}));
     }
     return getEvent();
 }


### PR DESCRIPTION
This pull request introduces several changes to the `Core` class and event handling mechanisms in the `src/core/Core.cpp` and `src/displays/SFML/SFMLDisplay.cpp` files. The changes focus on refactoring the event handling logic and improving the handling of game and display transitions.

Key changes include:

### Refactoring and Improvements:

* [`src/core/Core.cpp`](diffhunk://#diff-741534da0cd9c40ad17494337090dc0381db6f3e8a135e79bda070d256642003L94-R137): Refactored the `handleEventLibs` method to delegate game and display transitions to new `nextGame` and `nextDisplay` methods, simplifying the event handling logic.
* [`src/core/Core.cpp`](diffhunk://#diff-741534da0cd9c40ad17494337090dc0381db6f3e8a135e79bda070d256642003R154-R158): Introduced a `skipNext` flag to skip the next event in certain conditions, improving the event processing flow.
* [`src/core/Core.hpp`](diffhunk://#diff-49bf333e5416db8dca34c91efe93f2203e62cf19be4bf737e87a6c19848fc247R47-R48): Added declarations for the new `nextGame` and `nextDisplay` methods and the `skipNext` flag to the `Core` class. 

### Event Handling Enhancements:

* [`src/displays/SFML/SFMLDisplay.cpp`](diffhunk://#diff-afed13c307fa8ab7e9cb22bbbe8b5181494aa5f3096ac5b27e40da5c8e23994eL170-R170): Updated the `getEventKeyBoard` and `getEventMouse` methods to wrap event statuses in `std::any`, enhancing type safety and flexibility. 